### PR TITLE
Fix assemble deploy for pip

### DIFF
--- a/pip/BUILD
+++ b/pip/BUILD
@@ -35,7 +35,8 @@ py_binary(
     name = "assemble",
     srcs = ["assemble.py"],
     deps = [
-        vaticle_bazel_distribution_requirement("setuptools")
+        vaticle_bazel_distribution_requirement("setuptools"),
+        vaticle_bazel_distribution_requirement("wheel")
     ],
     visibility = ["//visibility:public"]
 )

--- a/pip/assemble.py
+++ b/pip/assemble.py
@@ -37,17 +37,20 @@ def create_init_files(directory):
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--output', help="Output archive")
+parser.add_argument('--output_sdist', help="Output archive")
+parser.add_argument('--output_wheel', help="Output archive")
 parser.add_argument('--setup_py', help="setup.py")
 parser.add_argument('--requirements_file', help="install_requires")
 parser.add_argument('--readme', help="README file")
 parser.add_argument('--files', nargs='+', help='Python files to pack into archive')
+parser.add_argument('--data_files', nargs='+', help='Data files to pack into archive')
 parser.add_argument('--imports', nargs='+', help='Folders considered to be source code roots')
 
 args = parser.parse_args()
 
 # absolutize the path
-args.output = os.path.abspath(args.output)
+args.output_sdist = os.path.abspath(args.output_sdist)
+args.output_wheel = os.path.abspath(args.output_wheel)
 # turn imports into regex patterns
 args.imports = list(map(
     lambda imp: re.compile('(?:.*){}[/]?(?P<fn>.*)'.format(imp)),
@@ -60,7 +63,7 @@ pkg_dir = tempfile.mkdtemp()
 if not args.files:
     raise Exception("Cannot create an archive without any files")
 
-for f in args.files:
+for f in args.files + args.data_files:
     fn = f
     for _imp in args.imports:
         match = _imp.match(fn)
@@ -74,6 +77,13 @@ for f in args.files:
         # directory already exists
         pass
     shutil.copy(f, os.path.join(pkg_dir, fn))
+
+# MANIFEST.in is needed for data files that are not included in version control
+if args.data_files:
+    manifest_in_path = os.path.join(pkg_dir, 'MANIFEST.in')
+    with open(manifest_in_path, 'w') as manifest_in:
+        for f in args.data_files:
+            manifest_in.write("include {}\n".format(f))
 
 setup_py = os.path.join(pkg_dir, 'setup.py')
 readme = os.path.join(pkg_dir, 'README.md')
@@ -104,11 +114,16 @@ os.chdir(pkg_dir)
 create_init_files(pkg_dir)
 
 # pack sources
-run_setup(setup_py, ['sdist'])
+run_setup(setup_py, ['sdist', 'bdist_wheel'])
 
-archives = glob.glob('dist/*.tar.gz')
-if len(archives) != 1:
+sdist_archives = glob.glob('dist/*.tar.gz')
+if len(sdist_archives) != 1:
     raise Exception('archive expected was not produced by sdist')
 
-shutil.copy(archives[0], args.output)
+wheel_archives = glob.glob('dist/*.whl')
+if len(wheel_archives) != 1:
+    raise Exception('archive expected was not produced by bdist_wheel')
+
+shutil.copy(sdist_archives[0], args.output_sdist)
+shutil.copy(wheel_archives[0], args.output_wheel)
 shutil.rmtree(pkg_dir)

--- a/pip/assemble.py
+++ b/pip/assemble.py
@@ -37,8 +37,8 @@ def create_init_files(directory):
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--output_sdist', help="Output archive")
-parser.add_argument('--output_wheel', help="Output archive")
+parser.add_argument('--output', '--output_sdist', help="Output sdist archive")
+parser.add_argument('--output_wheel', help="Output wheel archive")
 parser.add_argument('--setup_py', help="setup.py")
 parser.add_argument('--requirements_file', help="install_requires")
 parser.add_argument('--readme', help="README file")
@@ -49,7 +49,7 @@ parser.add_argument('--imports', nargs='+', help='Folders considered to be sourc
 args = parser.parse_args()
 
 # absolutize the path
-args.output_sdist = os.path.abspath(args.output_sdist)
+args.output = os.path.abspath(args.output)
 args.output_wheel = os.path.abspath(args.output_wheel)
 # turn imports into regex patterns
 args.imports = list(map(
@@ -124,6 +124,6 @@ wheel_archives = glob.glob('dist/*.whl')
 if len(wheel_archives) != 1:
     raise Exception('archive expected was not produced by bdist_wheel')
 
-shutil.copy(sdist_archives[0], args.output_sdist)
+shutil.copy(sdist_archives[0], args.output)
 shutil.copy(wheel_archives[0], args.output_wheel)
 shutil.rmtree(pkg_dir)

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -14,3 +14,8 @@ twine==1.12.1
 urllib3==1.26.5
 webencodings==0.5.1
 wheel==0.33.1
+six==1.16.0
+charset-normalizer==2.0.12
+packaging==21.3
+pyparsing==3.0.9
+

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -13,4 +13,4 @@ tqdm==4.29.1
 twine==1.12.1
 urllib3==1.26.5
 webencodings==0.5.1
-wheel==0.32.3
+wheel==0.33.1

--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -165,7 +165,7 @@ def _assemble_pip_impl(ctx):
 def _deploy_pip_impl(ctx):
     deployment_script = ctx.actions.declare_file("{}_deploy.py".format(ctx.attr.name))
     if ctx.attr.snapshot and ctx.attr.release:
-        fail(msg="canot deploy snapshot and release at the same time.")
+        fail(msg="cannot deploy snapshot and release at the same time.")
     if ctx.attr.snapshot and ctx.attr.pypi_profile:
         fail(msg="cannot deploy using pypi_profile and snapshot url at the same time.")
     if ctx.attr.release and ctx.attr.pypi_profile:

--- a/pip/templates/deploy.py
+++ b/pip/templates/deploy.py
@@ -29,53 +29,22 @@ sys.path.extend(map(os.path.abspath, glob.glob('external/*/*')))
 # noinspection PyUnresolvedReferences
 import twine.commands.upload
 
-parser = argparse.ArgumentParser()
-parser.add_argument('repo_type')
-args = parser.parse_args()
-
-repo_type_key = args.repo_type
-
-pip_repositories = {
-    'snapshot' : "{snapshot}",
-    'release' : "{release}"
-}
-
-pip_registry = pip_repositories[repo_type_key]
-
-pip_username, pip_password = (
-    os.getenv('DEPLOY_PIP_USERNAME'),
-    os.getenv('DEPLOY_PIP_PASSWORD'),
-)
-
-if not pip_username:
-    raise Exception(
-        'username should be passed via '
-        'DEPLOY_PIP_USERNAME env variable'
-    )
-
-if not pip_password:
-    raise Exception(
-        'password should be passed via '
-        '$DEPLOY_PIP_PASSWORD env variable'
-    )
-
 with open("{version_file}") as version_file:
     version = version_file.read().strip()
-
 new_package_file = None
-
+new_wheel_file = None
 try:
-    new_package_file = "{package_file}".replace(".tar.gz", "-{}.tar.gz".format(version))
+    os.mkdir("./dist")
+    new_package_file = "./dist/" + "{package_file}".replace(".tar.gz", "-{}.tar.gz".format(version))
+    new_wheel_file = "./dist/" + "{wheel_file}".replace(".whl", "-{}.whl".format(version))
+
     shutil.copy("{package_file}", new_package_file)
+    shutil.copy("{wheel_file}", new_wheel_file)
 
     twine.commands.upload.main([
-        new_package_file,
-        '-u',
-        pip_username,
-        '-p',
-        pip_password,
-        '--repository-url',
-        pip_registry
+        './dist/*',
+        '--repository',
+        'codeartifact'
     ])
 finally:
     if new_package_file:

--- a/pip/templates/setup.py
+++ b/pip/templates/setup.py
@@ -18,9 +18,9 @@
 #
 
 from setuptools import setup
-from setuptools import find_packages
+from setuptools import find_namespace_packages
 
-packages = find_packages()
+packages = find_namespace_packages()
 
 setup(
     name = "{name}",
@@ -35,7 +35,9 @@ setup(
     author_email = "{author_email}",
     license = "{license}",
     packages=packages,
+    include_package_data = True,
     install_requires=INSTALL_REQUIRES_PLACEHOLDER,
     zip_safe=False,
     python_requires="{python_requires}",
+    setup_requires=["wheel"]
 )


### PR DESCRIPTION
Currently there are some issues with these two rules: 'assemble_pip' and 'deploy_pip'.

assemble_pip: 
(1) data files are not included in "tarball" build; 
(2) it cannot produce "wheel" file which is a common needs for many use cases.

deploy_pip: 
(1) currently the deployment relies on "repository_registry" and username&password. However, we use "~/.pypirc" to config twine and we think many other users have the same config. "pypi_profile" attr is added to enable this use case;
(2) this rule will run into an error due to missing deps in requirements.txt;
(3) this rule will run into an error due to that the "repo_type_key" arg in deploy.py is missing when running the script. Practically, only one of "release" and "snapshot" can be used for deployment;
(4) this rule can only deploy single package ("tar.gz") which is incompatible with what we did for "assemble_pip".

This PR is to address all of the issues above.