### PR TITLE
use pip_parse

### DIFF
--- a/pip/deps.bzl
+++ b/pip/deps.bzl
@@ -1,7 +1,7 @@
-load("@rules_python//python:pip.bzl", "pip_install")
+load("@rules_python//python:pip.bzl", "pip_parse")
 
 def deps():
-    pip_install(
+    pip_parse(
         name = "vaticle_bazel_distribution_pip",
         requirements = "@vaticle_bazel_distribution//pip:requirements.txt",
     )


### PR DESCRIPTION
use `pip_parse` instead of `pip_install`

tested for `release-tools` with the new hash:
```
❯ bazel build //...
INFO: Invocation ID: 3f971c49-7149-4fdb-91cc-82285832d5c9
DEBUG: Rule 'vaticle_bazel_distribution' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1685643862 -0700"
DEBUG: Repository vaticle_bazel_distribution instantiated at:
  /Users/lyao/bazel/release-tools/WORKSPACE.bazel:54:15: in <toplevel>
Repository rule git_repository defined at:
  /private/var/tmp/_bazel_lyao/0019d17a4c4767640e02013e2a388bed/external/bazel_tools/tools/build_defs/repo/git.bzl:176:33: in <toplevel>
INFO: Analyzed 24 targets (141 packages loaded, 7758 targets configured).
INFO: Found 24 targets...
INFO: From Action confluent-release-tools.tar.gz:
/private/var/tmp/_bazel_lyao/0019d17a4c4767640e02013e2a388bed/sandbox/darwin-sandbox/6/execroot/__main__/bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/vaticle_bazel_distribution/pip/assemble.runfiles/vaticle_bazel_distribution_pip_setuptools/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
```